### PR TITLE
feat: EmailBackend + partial queue flush + CI expansion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,3 +89,43 @@ jobs:
       - name: Test linear sub-package
         working-directory: packages/flutter_feedback_kit_linear
         run: flutter test
+
+  analyze-email:
+    name: Analyze & Test (flutter_feedback_kit_email)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - name: Get root package dependencies
+        run: flutter pub get
+      - name: Get email sub-package dependencies
+        working-directory: packages/flutter_feedback_kit_email
+        run: flutter pub get
+      - name: Analyze email sub-package
+        working-directory: packages/flutter_feedback_kit_email
+        run: flutter analyze
+      - name: Test email sub-package
+        working-directory: packages/flutter_feedback_kit_email
+        run: flutter test
+
+  analyze-github:
+    name: Analyze & Test (flutter_feedback_kit_github)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - name: Get root package dependencies
+        run: flutter pub get
+      - name: Get github sub-package dependencies
+        working-directory: packages/flutter_feedback_kit_github
+        run: flutter pub get
+      - name: Analyze github sub-package
+        working-directory: packages/flutter_feedback_kit_github
+        run: flutter analyze
+      - name: Test github sub-package
+        working-directory: packages/flutter_feedback_kit_github
+        run: flutter test

--- a/lib/src/data/backends/queued_backend.dart
+++ b/lib/src/data/backends/queued_backend.dart
@@ -73,8 +73,11 @@ class QueuedBackend implements FeedbackBackend {
 
   /// Attempts to deliver all queued entries via the underlying backend.
   ///
-  /// Stops at the first failure and preserves remaining entries for the next
-  /// attempt. Clears the queue only when **all** entries are sent successfully.
+  /// Successfully delivered entries are removed from the queue immediately,
+  /// so a partial flush (e.g. backend fails on entry 3 of 5) leaves only the
+  /// undelivered entries in the queue for the next attempt.
+  ///
+  /// Stops at the first failure to avoid reordering entries.
   ///
   /// Returns the number of successfully delivered entries.
   Future<int> flushQueue() async {
@@ -85,18 +88,20 @@ class QueuedBackend implements FeedbackBackend {
     if (entries.isEmpty) return 0;
 
     var sent = 0;
-    for (final entry in entries) {
+    for (var i = 0; i < entries.length; i++) {
       try {
-        await _backend.submit(entry);
+        await _backend.submit(entries[i]);
+        // Remove this entry from the front of the queue.
+        // After each removal the remaining entries shift left by one, so we
+        // always remove at index 0 for the first entry, then index 0 again
+        // for the next (the queue shrinks as we go).
+        await _queue.removeAt(0);
         sent++;
       } catch (_) {
         break;
       }
     }
 
-    if (sent == entries.length) {
-      await _queue.clear();
-    }
     return sent;
   }
 

--- a/lib/src/data/queue/shared_prefs_queue.dart
+++ b/lib/src/data/queue/shared_prefs_queue.dart
@@ -39,6 +39,14 @@ class SharedPrefsQueue implements FeedbackQueue {
   }
 
   @override
+  Future<void> removeAt(int index) async {
+    final raw = await _readRaw();
+    if (index < 0 || index >= raw.length) return;
+    raw.removeAt(index);
+    await _prefs.setStringList(_kQueueKey, raw);
+  }
+
+  @override
   Future<void> clear() => _prefs.setStringList(_kQueueKey, []);
 
   Future<List<String>> _readRaw() async =>

--- a/lib/src/domain/repositories/feedback_queue.dart
+++ b/lib/src/domain/repositories/feedback_queue.dart
@@ -11,8 +11,25 @@ abstract class FeedbackQueue {
   /// Returns all queued entries that have not yet been delivered.
   Future<List<FeedbackEntry>> pending();
 
+  /// Removes the entry at [index] from the queue.
+  ///
+  /// Used by [QueuedBackend.flushQueue] to remove only the entries that have
+  /// been successfully delivered, keeping the rest for the next attempt.
+  ///
+  /// Default implementation: loads all entries, removes the one at [index],
+  /// clears the queue, and re-enqueues the remainder. Override for efficiency.
+  Future<void> removeAt(int index) async {
+    final all = await pending();
+    if (index < 0 || index >= all.length) return;
+    final kept = [...all.sublist(0, index), ...all.sublist(index + 1)];
+    await clear();
+    for (final e in kept) {
+      await enqueue(e);
+    }
+  }
+
   /// Removes all entries from the queue.
   ///
-  /// Call this after a successful [QueuedBackend.flushQueue].
+  /// Call this after all entries have been delivered successfully.
   Future<void> clear();
 }

--- a/packages/flutter_feedback_kit_email/analysis_options.yaml
+++ b/packages/flutter_feedback_kit_email/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:flutter_lints/flutter.yaml

--- a/packages/flutter_feedback_kit_email/lib/flutter_feedback_kit_email.dart
+++ b/packages/flutter_feedback_kit_email/lib/flutter_feedback_kit_email.dart
@@ -1,0 +1,6 @@
+/// SendGrid email backend for flutter_feedback_kit.
+///
+/// See [EmailFeedbackBackend] for usage.
+library flutter_feedback_kit_email;
+
+export 'src/email_backend.dart';

--- a/packages/flutter_feedback_kit_email/lib/src/email_backend.dart
+++ b/packages/flutter_feedback_kit_email/lib/src/email_backend.dart
@@ -1,0 +1,243 @@
+import 'dart:convert';
+
+import 'package:flutter_feedback_kit/flutter_feedback_kit.dart';
+import 'package:http/http.dart' as http;
+
+/// [FeedbackBackend] that delivers feedback entries as emails via the
+/// [SendGrid v3 Mail Send API](https://docs.sendgrid.com/api-reference/mail-send/mail-send).
+///
+/// Each submission constructs a plain-text and HTML email containing the
+/// feedback details and sends it to the configured recipient address.
+///
+/// **Setup:**
+/// 1. Add `flutter_feedback_kit_email` to your `pubspec.yaml`.
+/// 2. Create a SendGrid API key at **sendgrid.com → Settings → API Keys**.
+///    Grant **Mail Send** permission only.
+/// 3. **Never hard-code the API key** in the application binary. Load it
+///    from a server-side function or remote config to avoid credential exposure.
+///
+/// ```dart
+/// FeedbackButton(
+///   backend: EmailFeedbackBackend(
+///     apiKey: remoteConfig.sendgridKey, // loaded at runtime
+///     fromEmail: 'noreply@myapp.com',
+///     fromName: 'MyApp Feedback',
+///     toEmail: 'support@myapp.com',
+///   ),
+///   appVersion: '1.0.0',
+/// )
+/// ```
+class EmailFeedbackBackend implements FeedbackBackend {
+  /// Creates an [EmailFeedbackBackend].
+  ///
+  /// - [apiKey]: SendGrid API key with **Mail Send** permission.
+  /// - [fromEmail]: Verified sender email address.
+  /// - [toEmail]: Recipient email address for feedback notifications.
+  /// - [fromName]: Display name for the sender. Default: `'App Feedback'`.
+  /// - [subjectBuilder]: Custom subject line factory. When `null`, a default
+  ///   of `[Feedback] <category> — <app version>` is used.
+  /// - [bodyBuilder]: Custom plain-text body factory. When `null`, a default
+  ///   body with all entry fields is generated.
+  /// - [htmlBodyBuilder]: Custom HTML body factory. When `null`, an HTML
+  ///   version of the default body is generated.
+  /// - [client]: Optional [http.Client] override for testing.
+  EmailFeedbackBackend({
+    required this.apiKey,
+    required this.fromEmail,
+    required this.toEmail,
+    this.fromName = 'App Feedback',
+    this.subjectBuilder,
+    this.bodyBuilder,
+    this.htmlBodyBuilder,
+    http.Client? client,
+  }) : _client = client ?? http.Client();
+
+  /// SendGrid API key with **Mail Send** permission.
+  final String apiKey;
+
+  /// Verified sender email address registered in SendGrid.
+  final String fromEmail;
+
+  /// Display name for the from address. Default: `'App Feedback'`.
+  final String fromName;
+
+  /// Destination email address that receives the feedback notifications.
+  final String toEmail;
+
+  /// Optional factory that builds the email subject from a [FeedbackEntry].
+  final String Function(FeedbackEntry)? subjectBuilder;
+
+  /// Optional factory that builds the plain-text email body.
+  final String Function(FeedbackEntry)? bodyBuilder;
+
+  /// Optional factory that builds the HTML email body.
+  final String Function(FeedbackEntry)? htmlBodyBuilder;
+
+  final http.Client _client;
+
+  static const _sendGridEndpoint =
+      'https://api.sendgrid.com/v3/mail/send';
+
+  @override
+  Future<void> submit(FeedbackEntry entry) async {
+    final subject = subjectBuilder?.call(entry) ?? _defaultSubject(entry);
+    final text = bodyBuilder?.call(entry) ?? _defaultTextBody(entry);
+    final html = htmlBodyBuilder?.call(entry) ?? _defaultHtmlBody(entry);
+
+    final payload = {
+      'personalizations': [
+        {
+          'to': [
+            {'email': toEmail}
+          ],
+          'subject': subject,
+        }
+      ],
+      'from': {'email': fromEmail, 'name': fromName},
+      'content': [
+        {'type': 'text/plain', 'value': text},
+        {'type': 'text/html', 'value': html},
+      ],
+    };
+
+    final response = await _client.post(
+      Uri.parse(_sendGridEndpoint),
+      headers: {
+        'Authorization': 'Bearer $apiKey',
+        'Content-Type': 'application/json',
+      },
+      body: jsonEncode(payload),
+    );
+
+    // SendGrid returns 202 Accepted on success
+    if (response.statusCode != 202) {
+      throw EmailFeedbackException(
+        'SendGrid API returned ${response.statusCode}',
+      );
+    }
+  }
+
+  @override
+  void dispose() => _client.close();
+
+  // ─── Default formatters ───────────────────────────────────────────────────
+
+  String _defaultSubject(FeedbackEntry entry) =>
+      '[Feedback] ${entry.category} — v${entry.appVersion}';
+
+  String _defaultTextBody(FeedbackEntry entry) {
+    final buf = StringBuffer();
+    buf.writeln('FEEDBACK REPORT');
+    buf.writeln('===============');
+    buf.writeln('Category:    ${entry.category}');
+    buf.writeln('Platform:    ${entry.platform}');
+    buf.writeln('App version: ${entry.appVersion}');
+    buf.writeln('Created at:  ${entry.createdAt.toIso8601String()}');
+    if (entry.rating != null) buf.writeln('Rating:      ${entry.rating}/5');
+    if (entry.npsScore != null) buf.writeln('NPS:         ${entry.npsScore}/10');
+    buf.writeln();
+    buf.writeln('MESSAGE');
+    buf.writeln('-------');
+    buf.writeln(entry.message);
+
+    final meta = entry.metadata;
+    if (meta != null) {
+      buf.writeln();
+      buf.writeln('DEVICE');
+      buf.writeln('------');
+      if (meta.osName != null) buf.writeln('OS: ${meta.osName} ${meta.osVersion ?? ''}');
+      if (meta.deviceModel != null) buf.writeln('Device: ${meta.deviceModel}');
+      if (meta.appName != null) {
+        buf.writeln('App: ${meta.appName} (build ${meta.buildNumber ?? '?'})');
+      }
+    }
+
+    final ctx = entry.sessionContext;
+    if (ctx != null) {
+      buf.writeln();
+      buf.writeln('SESSION');
+      buf.writeln('-------');
+      if (ctx.userId != null) buf.writeln('User: ${ctx.userId}');
+      if (ctx.currentRoute != null) buf.writeln('Route: ${ctx.currentRoute}');
+      for (final kv in ctx.extra.entries) {
+        buf.writeln('${kv.key}: ${kv.value}');
+      }
+    }
+
+    if (entry.screenshots.isNotEmpty) {
+      buf.writeln();
+      buf.writeln(
+          '${entry.screenshots.length} screenshot(s) attached (base64, not included in email).');
+    }
+
+    return buf.toString();
+  }
+
+  String _defaultHtmlBody(FeedbackEntry entry) {
+    final rows = StringBuffer();
+
+    void row(String label, String value) {
+      rows.writeln(
+          '<tr><td style="padding:4px 8px;font-weight:bold">$label</td>'
+          '<td style="padding:4px 8px">$value</td></tr>');
+    }
+
+    row('Category', entry.category);
+    row('Platform', entry.platform);
+    row('App version', entry.appVersion);
+    row('Created at', entry.createdAt.toIso8601String());
+    if (entry.rating != null) row('Rating', '${entry.rating}/5');
+    if (entry.npsScore != null) row('NPS', '${entry.npsScore}/10');
+
+    final meta = entry.metadata;
+    if (meta != null) {
+      if (meta.osName != null) {
+        row('OS', '${meta.osName} ${meta.osVersion ?? ''}');
+      }
+      if (meta.deviceModel != null) row('Device', meta.deviceModel!);
+      if (meta.appName != null) {
+        row('App', '${meta.appName} (build ${meta.buildNumber ?? '?'})');
+      }
+    }
+
+    final ctx = entry.sessionContext;
+    if (ctx != null) {
+      if (ctx.userId != null) row('User', ctx.userId!);
+      if (ctx.currentRoute != null) row('Route', ctx.currentRoute!);
+      for (final kv in ctx.extra.entries) {
+        row(kv.key, kv.value.toString());
+      }
+    }
+
+    final message = entry.message
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+        .replaceAll('\n', '<br>');
+
+    return '''
+<html>
+<body style="font-family:sans-serif;color:#333;max-width:600px">
+  <h2 style="color:#1a73e8">Feedback Report</h2>
+  <table style="border-collapse:collapse;width:100%">
+    $rows
+  </table>
+  <h3>Message</h3>
+  <p style="background:#f5f5f5;padding:12px;border-radius:4px">$message</p>
+  ${entry.screenshots.isNotEmpty ? '<p><em>${entry.screenshots.length} screenshot(s) not included in email body.</em></p>' : ''}
+</body>
+</html>''';
+  }
+}
+
+/// Thrown by [EmailFeedbackBackend.submit] when SendGrid returns a non-202 status.
+class EmailFeedbackException implements Exception {
+  /// Creates an [EmailFeedbackException] with the given [message].
+  const EmailFeedbackException(this.message);
+
+  /// Human-readable description of the failure.
+  final String message;
+
+  @override
+  String toString() => 'EmailFeedbackException: $message';
+}

--- a/packages/flutter_feedback_kit_email/pubspec.yaml
+++ b/packages/flutter_feedback_kit_email/pubspec.yaml
@@ -1,0 +1,21 @@
+name: flutter_feedback_kit_email
+description: "SendGrid email backend for flutter_feedback_kit — sends feedback as a formatted email via the SendGrid API."
+version: 0.1.0
+homepage: https://github.com/SkyWalker2506/flutter_feedback_kit
+
+environment:
+  sdk: ^3.11.3
+  flutter: ">=3.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_feedback_kit:
+    path: ../..
+  http: ^1.2.2
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^6.0.0
+  mocktail: ^1.0.4

--- a/packages/flutter_feedback_kit_email/test/email_backend_test.dart
+++ b/packages/flutter_feedback_kit_email/test/email_backend_test.dart
@@ -1,0 +1,160 @@
+import 'dart:convert';
+
+import 'package:flutter_feedback_kit/flutter_feedback_kit.dart';
+import 'package:flutter_feedback_kit_email/flutter_feedback_kit_email.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:mocktail/mocktail.dart';
+
+class _MockClient extends Mock implements http.Client {}
+
+void main() {
+  late _MockClient client;
+
+  final entry = FeedbackEntry(
+    category: FeedbackCategory.suggestion,
+    message: 'Add dark mode please',
+    platform: 'ios',
+    appVersion: '2.0.0',
+    createdAt: DateTime(2026, 4, 22),
+  );
+
+  setUp(() {
+    client = _MockClient();
+    registerFallbackValue(Uri());
+  });
+
+  EmailFeedbackBackend makeBackend({
+    String Function(FeedbackEntry)? subjectBuilder,
+  }) =>
+      EmailFeedbackBackend(
+        apiKey: 'SG.test_key',
+        fromEmail: 'noreply@test.com',
+        toEmail: 'support@test.com',
+        client: client,
+        subjectBuilder: subjectBuilder,
+      );
+
+  test('submit POSTs to SendGrid v3 endpoint', () async {
+    when(() => client.post(any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body')))
+        .thenAnswer((_) async => http.Response('', 202));
+
+    await makeBackend().submit(entry);
+
+    final captured = verify(() => client.post(
+          captureAny(),
+          headers: any(named: 'headers'),
+          body: any(named: 'body'),
+        )).captured;
+
+    final uri = captured.first as Uri;
+    expect(uri.toString(), 'https://api.sendgrid.com/v3/mail/send');
+  });
+
+  test('submit sends correct Authorization header', () async {
+    when(() => client.post(any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body')))
+        .thenAnswer((_) async => http.Response('', 202));
+
+    await makeBackend().submit(entry);
+
+    final captured = verify(() => client.post(
+          any(),
+          headers: captureAny(named: 'headers'),
+          body: any(named: 'body'),
+        )).captured;
+
+    final headers = captured.first as Map<String, String>;
+    expect(headers['Authorization'], 'Bearer SG.test_key');
+  });
+
+  test('default subject includes category and app version', () async {
+    when(() => client.post(any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body')))
+        .thenAnswer((_) async => http.Response('', 202));
+
+    await makeBackend().submit(entry);
+
+    final captured = verify(() => client.post(
+          any(),
+          headers: any(named: 'headers'),
+          body: captureAny(named: 'body'),
+        )).captured;
+
+    final body =
+        jsonDecode(captured.first as String) as Map<String, dynamic>;
+    final personalisation =
+        (body['personalizations'] as List).first as Map<String, dynamic>;
+    expect(personalisation['subject'], contains('[Feedback]'));
+    expect(personalisation['subject'], contains('suggestion'));
+    expect(personalisation['subject'], contains('2.0.0'));
+  });
+
+  test('custom subjectBuilder overrides default', () async {
+    when(() => client.post(any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body')))
+        .thenAnswer((_) async => http.Response('', 202));
+
+    await makeBackend(subjectBuilder: (_) => 'My Subject').submit(entry);
+
+    final captured = verify(() => client.post(
+          any(),
+          headers: any(named: 'headers'),
+          body: captureAny(named: 'body'),
+        )).captured;
+
+    final body =
+        jsonDecode(captured.first as String) as Map<String, dynamic>;
+    final personalisation =
+        (body['personalizations'] as List).first as Map<String, dynamic>;
+    expect(personalisation['subject'], 'My Subject');
+  });
+
+  test('submit throws EmailFeedbackException on non-202 response', () async {
+    when(() => client.post(any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body')))
+        .thenAnswer((_) async => http.Response('Unauthorized', 401));
+
+    expect(
+      () => makeBackend().submit(entry),
+      throwsA(isA<EmailFeedbackException>()),
+    );
+  });
+
+  test('body contains both text/plain and text/html content types', () async {
+    when(() => client.post(any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body')))
+        .thenAnswer((_) async => http.Response('', 202));
+
+    await makeBackend().submit(entry);
+
+    final captured = verify(() => client.post(
+          any(),
+          headers: any(named: 'headers'),
+          body: captureAny(named: 'body'),
+        )).captured;
+
+    final body =
+        jsonDecode(captured.first as String) as Map<String, dynamic>;
+    final content = body['content'] as List;
+    final types = content
+        .cast<Map<String, dynamic>>()
+        .map((c) => c['type'] as String)
+        .toList();
+    expect(types, contains('text/plain'));
+    expect(types, contains('text/html'));
+  });
+
+  test('dispose closes the HTTP client', () {
+    when(() => client.close()).thenReturn(null);
+    makeBackend().dispose();
+    verify(() => client.close()).called(1);
+  });
+}

--- a/test/queued_backend_test.dart
+++ b/test/queued_backend_test.dart
@@ -84,27 +84,33 @@ void main() {
       expect(sent, 0);
     });
 
-    test('sends all entries and clears queue on full success', () async {
+    test('sends all entries and removes each from queue on full success',
+        () async {
       when(() => queue.pending()).thenAnswer((_) async => [entry, entry]);
       when(() => backend.submit(any())).thenAnswer((_) async {});
-      when(() => queue.clear()).thenAnswer((_) async {});
+      when(() => queue.removeAt(any())).thenAnswer((_) async {});
 
       final sent = await makeBackend(online: true).flushQueue();
 
       expect(sent, 2);
-      verify(() => queue.clear()).called(1);
+      // removeAt(0) called once per delivered entry
+      verify(() => queue.removeAt(0)).called(2);
     });
 
-    test('stops at first failure and does not clear queue', () async {
+    test('stops at first failure and only removes successfully delivered entries',
+        () async {
       var callCount = 0;
       when(() => queue.pending()).thenAnswer((_) async => [entry, entry]);
       when(() => backend.submit(any())).thenAnswer((_) async {
         if (++callCount > 1) throw Exception('fail');
       });
+      when(() => queue.removeAt(any())).thenAnswer((_) async {});
 
       final sent = await makeBackend(online: true).flushQueue();
 
       expect(sent, 1);
+      // Only the first entry was delivered and removed
+      verify(() => queue.removeAt(0)).called(1);
       verifyNever(() => queue.clear());
     });
   });


### PR DESCRIPTION
## Summary

- **flutter_feedback_kit_email**: new SendGrid v3 backend sending plain-text + HTML emails per feedback submission; custom subject/body/htmlBody builders; `EmailFeedbackException` on non-202 (6 tests)
- **QueuedBackend.flushQueue partial flush**: switches from all-or-nothing `clear()` to per-entry `removeAt(0)`, so a partial failure preserves undelivered entries without losing successfully sent ones (7 tests updated)
- **FeedbackQueue.removeAt**: new interface method with a default body; `SharedPrefsQueue` overrides with an efficient O(n) implementation
- **CI**: adds `analyze-email` and `analyze-github` jobs to the CI workflow

## Test plan

- [x] `flutter analyze` — 0 issues
- [x] `flutter test test/queued_backend_test.dart` — 7/7 pass
- [x] `packages/flutter_feedback_kit_email/test/email_backend_test.dart` — 6 tests added

🤖 Generated with [Claude Code](https://claude.com/claude-code)