### PR TITLE
feat: v0.2.0 release — FeedbackTrigger tests + version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
-## 0.2.0 (Unreleased)
+## 0.2.0
+
+### Sprint 10 (Forge Runs 1-3)
+- `PiiSanitizerMiddleware` — redacts email addresses and phone numbers from the feedback message before backend delivery; supports custom regex patterns and replacement strings
+- `flutter_feedback_kit_github` sub-package — creates GitHub Issues via REST API v3 on feedback submission; custom title/body/label support
+- `flutter_feedback_kit_email` sub-package — delivers feedback as SendGrid v3 emails (plain-text + HTML); custom subject/body/htmlBody builders
+- `QueuedBackend.flushQueue` — improved partial flush: successfully delivered entries are removed immediately via `removeAt`, so a partial failure does not re-send already-delivered entries
+- `FeedbackQueue.removeAt` — new interface method for per-entry removal; `SharedPrefsQueue` overrides with O(n) implementation
+- `FeedbackTrigger` — comprehensive unit-test coverage (8 tests); uses `InMemorySharedPreferencesAsync` for isolation
 
 ### Breaking Changes
 - `LocalFeedbackBackend(directory: Directory)` → `LocalFeedbackBackend(directoryPath: String)` — removes `dart:io` from the public API

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_feedback_kit
 description: "In-app user feedback for Flutter — customisable form widget, voice input, offline queue, screenshot capture, and pluggable backends (webhook, Firebase, etc.)."
-version: 0.1.2
+version: 0.2.0
 homepage: https://github.com/SkyWalker2506/flutter_feedback_kit
 
 topics:
@@ -31,5 +31,6 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ^6.0.0
   mocktail: ^1.0.4
+  shared_preferences_platform_interface: ^2.4.0
 
 flutter:

--- a/test/feedback_trigger_test.dart
+++ b/test/feedback_trigger_test.dart
@@ -1,0 +1,133 @@
+import 'package:flutter_feedback_kit/flutter_feedback_kit.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferencesAsyncPlatform.instance =
+        InMemorySharedPreferencesAsync.empty();
+  });
+
+  group('FeedbackTrigger.shouldShow', () {
+    test('returns false when launches are below threshold', () async {
+      final trigger = FeedbackTrigger(
+        minAppLaunches: 5,
+        minDaysInstalled: 0,
+        repeatAfterDays: 0,
+      );
+
+      // Record 3 launches (below threshold of 5)
+      for (var i = 0; i < 3; i++) {
+        await trigger.recordLaunch();
+      }
+
+      expect(await trigger.shouldShow(), isFalse);
+    });
+
+    test('returns true once launch threshold is met', () async {
+      final trigger = FeedbackTrigger(
+        minAppLaunches: 3,
+        minDaysInstalled: 0,
+        repeatAfterDays: 999,
+      );
+
+      for (var i = 0; i < 3; i++) {
+        await trigger.recordLaunch();
+      }
+
+      expect(await trigger.shouldShow(), isTrue);
+    });
+
+    test('returns false after markShown until repeatAfterDays elapses',
+        () async {
+      final trigger = FeedbackTrigger(
+        minAppLaunches: 1,
+        minDaysInstalled: 0,
+        repeatAfterDays: 30,
+      );
+
+      await trigger.recordLaunch();
+      expect(await trigger.shouldShow(), isTrue);
+
+      await trigger.markShown();
+      // Still within the 30-day repeat window
+      expect(await trigger.shouldShow(), isFalse);
+    });
+
+    test('returns false forever after markNeverShow', () async {
+      final trigger = FeedbackTrigger(
+        minAppLaunches: 1,
+        minDaysInstalled: 0,
+        repeatAfterDays: 0,
+      );
+
+      await trigger.recordLaunch();
+      await trigger.markNeverShow();
+
+      expect(await trigger.shouldShow(), isFalse);
+    });
+
+    test('reset clears all state', () async {
+      final trigger = FeedbackTrigger(
+        minAppLaunches: 1,
+        minDaysInstalled: 0,
+        repeatAfterDays: 0,
+      );
+
+      await trigger.recordLaunch();
+      await trigger.markNeverShow();
+      await trigger.reset();
+
+      // After reset, launches = 0 → should not show yet
+      expect(await trigger.shouldShow(), isFalse);
+    });
+
+    test('oncePerVersion suppresses repeat within same version', () async {
+      final trigger = FeedbackTrigger(
+        minAppLaunches: 1,
+        minDaysInstalled: 0,
+        repeatAfterDays: 0,
+        oncePerVersion: true,
+      );
+
+      await trigger.recordLaunch();
+      expect(await trigger.shouldShow(appVersion: '1.0.0'), isTrue);
+
+      await trigger.markShown(appVersion: '1.0.0');
+      expect(await trigger.shouldShow(appVersion: '1.0.0'), isFalse);
+    });
+
+    test('oncePerVersion shows again for a new version', () async {
+      final trigger = FeedbackTrigger(
+        minAppLaunches: 1,
+        minDaysInstalled: 0,
+        repeatAfterDays: 0,
+        oncePerVersion: true,
+      );
+
+      await trigger.recordLaunch();
+      await trigger.markShown(appVersion: '1.0.0');
+
+      // New version — should be allowed to show again
+      expect(await trigger.shouldShow(appVersion: '2.0.0'), isTrue);
+    });
+  });
+
+  group('FeedbackTrigger.recordLaunch', () {
+    test('increments launch count on each call', () async {
+      final trigger = FeedbackTrigger(
+        minAppLaunches: 3,
+        minDaysInstalled: 0,
+        repeatAfterDays: 999,
+      );
+
+      await trigger.recordLaunch();
+      await trigger.recordLaunch();
+      expect(await trigger.shouldShow(), isFalse); // 2 < 3
+
+      await trigger.recordLaunch();
+      expect(await trigger.shouldShow(), isTrue); // 3 == 3
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- **Version bump**: 0.1.2 → 0.2.0; CHANGELOG promoted from (Unreleased) to released
- **FeedbackTrigger tests**: 8 comprehensive unit tests covering launch threshold, markShown/markNeverShow, reset, and oncePerVersion behaviour; uses `InMemorySharedPreferencesAsync` for proper isolation without platform channel setup
- **dev dependency**: added `shared_preferences_platform_interface` explicitly to enable async prefs mocking in tests

## Test plan

- [x] `flutter analyze` — 0 issues
- [x] `flutter test` — 78/78 pass (8 new FeedbackTrigger tests)

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)